### PR TITLE
Titan platoons and squads

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+#### v3.1.6 - 2016/01/26
+
+- Titans now properly excluded from teleporter platoons
+- Titans now properly excluded from general squads in hover platoons
+
 #### v3.1.5 - 2016/01/22
 
 - Fixed an issue that could cause only one Advanced Air Factory to build anything

--- a/pa/ai/platoon_templates/platoon_templates_hover.json
+++ b/pa/ai/platoon_templates/platoon_templates_hover.json
@@ -9,7 +9,7 @@
           "squad": "Artillery"
         },
         {
-          "unit_types": "Hover & Tank",
+          "unit_types": "(Hover & Land) - Titan",
           "min_count": 0,
           "max_count": 9,
           "squad": "General"
@@ -25,7 +25,7 @@
           "squad": "Artillery"
         },
         {
-          "unit_types": "Hover & Tank",
+          "unit_types": "(Hover & Land) - Titan",
           "min_count": 0,
           "max_count": 21,
           "squad": "General"
@@ -53,7 +53,7 @@
           "squad": "Artillery"
         },
         {
-          "unit_types": "Hover & Tank",
+          "unit_types": "(Hover & Land) - Titan",
           "min_count": 0,
           "max_count": 33,
           "squad": "General"
@@ -81,7 +81,7 @@
           "squad": "Artillery"
         },
         {
-          "unit_types": "Hover & Tank",
+          "unit_types": "(Hover & Land) - Titan",
           "min_count": 0,
           "max_count": -1,
           "squad": "General"

--- a/pa/ai/platoon_templates/platoon_templates_land.json
+++ b/pa/ai/platoon_templates/platoon_templates_land.json
@@ -11,13 +11,13 @@
     "Teleporter_Attack_40": {
       "units": [
         {
-          "unit_types": "(Tank & Mobile) - Fabber - AirDefense - Construction - Artillery - Heavy - Scout - SelfDestruct",
+          "unit_types": "(Tank & Mobile) - Fabber - AirDefense - Construction - Artillery - Heavy - Scout - SelfDestruct - Titan",
           "min_count": 0,
           "max_count": 49,
           "squad": "General"
         },
         {
-          "unit_types": "(Bot & Mobile) - Fabber - AirDefense - Construction - Artillery - Heavy - Scout - SelfDestruct",
+          "unit_types": "(Bot & Mobile) - Fabber - AirDefense - Construction - Artillery - Heavy - Scout - SelfDestruct - Titan",
           "min_count": 0,
           "max_count": 49,
           "squad": "Fast"
@@ -51,13 +51,13 @@
     "Teleporter_Attack_80": {
       "units": [
         {
-          "unit_types": "(Tank & Mobile) - Fabber - AirDefense - Construction - Artillery - Heavy - Scout - SelfDestruct",
+          "unit_types": "(Tank & Mobile) - Fabber - AirDefense - Construction - Artillery - Heavy - Scout - SelfDestruct - Titan",
           "min_count": 0,
           "max_count": -1,
           "squad": "General"
         },
         {
-          "unit_types": "(Bot & Mobile) - Fabber - AirDefense - Construction - Artillery - Heavy - Scout - SelfDestruct",
+          "unit_types": "(Bot & Mobile) - Fabber - AirDefense - Construction - Artillery - Heavy - Scout - SelfDestruct - Titan",
           "min_count": 0,
           "max_count": -1,
           "squad": "Fast"


### PR DESCRIPTION
- Titans now properly excluded from teleporter platoons
- Titans now properly excluded from general squads in hover platoons
